### PR TITLE
Fix github action eslint error

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: 'Reviewdog: ESLint'
         uses: reviewdog/action-eslint@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: 'github-pr-review'
           fail_on_error: true
           eslint_flags: '--ext .js,.jsx,.ts,.tsx ./'

--- a/server/package.json
+++ b/server/package.json
@@ -114,7 +114,7 @@
     "nyc": "^15.1.0",
     "sinon": "^14.0.0",
     "supertest": "^6.2.3",
-    "typedoc": "^0.22.17",
+    "typedoc": "^0.23.10",
     "typedoc-plugin-external-module-map": "^1.3.2",
     "typedoc-plugin-markdown": "^3.12.1"
   }


### PR DESCRIPTION
Fix github_token syntax (cf [documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication))